### PR TITLE
Prevent rate limiting when running `tflint --init`

### DIFF
--- a/.github/workflows/Terraform.yml
+++ b/.github/workflows/Terraform.yml
@@ -47,7 +47,7 @@ on:
 
 permissions:
   contents: read
-  
+
 env:
   # https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_in_automation
   TF_IN_AUTOMATION: true
@@ -167,6 +167,8 @@ jobs:
 
       - name: Initialise TFLint
         run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
 
       - name: Lint
         if: inputs.tflint-config-file != ''


### PR DESCRIPTION
# Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Adds `${{ github.token }}` to the `tflint --init` stage to prevent rate limiting as per their guidance
